### PR TITLE
Add checks to verify states before changing

### DIFF
--- a/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
+++ b/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
@@ -36,8 +36,6 @@ public class CycleStateGuide extends InteractionGuide {
         BlockState targetState = state.targetState;
         BlockState currentState = state.currentState;
 
-        
-        
         if (currentState.getBlock() == Blocks.REPEATER) {
             if (currentState.get(RepeaterBlock.DELAY) == targetState.get(RepeaterBlock.DELAY)) {
                 return false;
@@ -68,8 +66,6 @@ public class CycleStateGuide extends InteractionGuide {
                 return false;
             }
         }
-
-
         
         return !statesEqual(targetState, currentState);
     }

--- a/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
+++ b/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
@@ -36,6 +36,41 @@ public class CycleStateGuide extends InteractionGuide {
         BlockState targetState = state.targetState;
         BlockState currentState = state.currentState;
 
+        
+        
+        if (currentState.getBlock() == Blocks.REPEATER) {
+            if (currentState.get(RepeaterBlock.DELAY) == targetState.get(RepeaterBlock.DELAY)) {
+                return false;
+            }
+        }
+        if (currentState.getBlock() == Blocks.LEVER) {
+            if (currentState.get(LeverBlock.POWERED) == targetState.get(LeverBlock.POWERED)) {
+                return false;
+            }
+        }
+        if (currentState.getBlock() == Blocks.COMPARATOR) {
+            if (currentState.get(ComparatorBlock.MODE) == targetState.get(ComparatorBlock.MODE)) {
+                return false;
+            }
+        }
+        if (currentState.getBlock() instanceof TrapdoorBlock) {
+            if (currentState.get(TrapdoorBlock.OPEN) == targetState.get(TrapdoorBlock.OPEN)) {
+                return false;
+            }
+        }
+        if (currentState.getBlock() instanceof DoorBlock) {
+            if (currentState.get(DoorBlock.OPEN) == targetState.get(DoorBlock.OPEN)) {
+                return false;
+            }
+        }
+        if (currentState.getBlock() instanceof FenceGateBlock) {
+            if (currentState.get(FenceGateBlock.OPEN) == targetState.get(FenceGateBlock.OPEN)) {
+                return false;
+            }
+        }
+
+
+        
         return !statesEqual(targetState, currentState);
     }
 


### PR DESCRIPTION
Verify that the state that is modified by interaction is not already correct before interacting with the block. Fixes repetitive toggling of blocks when not rotated correctly.