### PR TITLE
Adding blacklisted tags to the ignore properties is a cleaner method than whitelisting with multiple if statements.

### DIFF
--- a/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
+++ b/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
@@ -15,11 +15,11 @@ public class CycleStateGuide extends InteractionGuide {
     private static final Property<?>[] propertiesToIgnore = new Property[]{
             Properties.POWERED,
             Properties.LIT,
-            Properties.FACE,
+            Properties.BLOCK_FACE,
             Properties.FACING,
             Properties.LOCKED,
-            Properties.HALF,
-            Properties.HINGE,
+            Properties.BLOCK_HALF,
+            Properties.DOOR_HINGE,
             Properties.IN_WALL
     };
 
@@ -42,24 +42,17 @@ public class CycleStateGuide extends InteractionGuide {
         BlockState targetState = state.targetState;
         BlockState currentState = state.currentState;
 
-        if (currentState.get(LeverBlock.POWERED) == targetState.get(LeverBlock.POWERED)) {
-            return false;
+        if (currentState.getBlock() == Blocks.LEVER) {
+            if (currentState.get(LeverBlock.POWERED) == targetState.get(LeverBlock.POWERED)) {
+                return false; // Lever blocks must be toggled if POWERED property is incorrect, regardless of other properties
+            }
+            return true;
         }
-
-        return !statesEqual(targetState, currentState);
+        return !statesEqualIgnoreProperties(targetState, currentState, propertiesToIgnore);
     }
 
     @Override
     protected @NotNull List<ItemStack> getRequiredItems() {
         return Collections.singletonList(ItemStack.EMPTY);
-    }
-
-    @Override
-    protected boolean statesEqual(BlockState state1, BlockState state2) {
-        if (state2.getBlock() instanceof LeverBlock) {
-            return super.statesEqualIgnoreProperties(state1, state2);
-        }
-
-        return statesEqualIgnoreProperties(state1, state2, propertiesToIgnore);
     }
 }

--- a/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
+++ b/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
@@ -20,7 +20,8 @@ public class CycleStateGuide extends InteractionGuide {
             Properties.LOCKED,
             Properties.BLOCK_HALF,
             Properties.DOOR_HINGE,
-            Properties.IN_WALL
+            Properties.IN_WALL,
+            RepeaterBlock.FACING
     };
 
     public CycleStateGuide(SchematicBlockState state) {

--- a/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
+++ b/v1_21_4/src/main/java/me/aleksilassila/litematica/printer/v1_21_4/guides/interaction/CycleStateGuide.java
@@ -14,7 +14,13 @@ import java.util.List;
 public class CycleStateGuide extends InteractionGuide {
     private static final Property<?>[] propertiesToIgnore = new Property[]{
             Properties.POWERED,
-            Properties.LIT
+            Properties.LIT,
+            Properties.FACE,
+            Properties.FACING,
+            Properties.LOCKED,
+            Properties.HALF,
+            Properties.HINGE,
+            Properties.IN_WALL
     };
 
     public CycleStateGuide(SchematicBlockState state) {
@@ -36,37 +42,10 @@ public class CycleStateGuide extends InteractionGuide {
         BlockState targetState = state.targetState;
         BlockState currentState = state.currentState;
 
-        if (currentState.getBlock() == Blocks.REPEATER) {
-            if (currentState.get(RepeaterBlock.DELAY) == targetState.get(RepeaterBlock.DELAY)) {
-                return false;
-            }
+        if (currentState.get(LeverBlock.POWERED) == targetState.get(LeverBlock.POWERED)) {
+            return false;
         }
-        if (currentState.getBlock() == Blocks.LEVER) {
-            if (currentState.get(LeverBlock.POWERED) == targetState.get(LeverBlock.POWERED)) {
-                return false;
-            }
-        }
-        if (currentState.getBlock() == Blocks.COMPARATOR) {
-            if (currentState.get(ComparatorBlock.MODE) == targetState.get(ComparatorBlock.MODE)) {
-                return false;
-            }
-        }
-        if (currentState.getBlock() instanceof TrapdoorBlock) {
-            if (currentState.get(TrapdoorBlock.OPEN) == targetState.get(TrapdoorBlock.OPEN)) {
-                return false;
-            }
-        }
-        if (currentState.getBlock() instanceof DoorBlock) {
-            if (currentState.get(DoorBlock.OPEN) == targetState.get(DoorBlock.OPEN)) {
-                return false;
-            }
-        }
-        if (currentState.getBlock() instanceof FenceGateBlock) {
-            if (currentState.get(FenceGateBlock.OPEN) == targetState.get(FenceGateBlock.OPEN)) {
-                return false;
-            }
-        }
-        
+
         return !statesEqual(targetState, currentState);
     }
 


### PR DESCRIPTION
this also fixes not toggling comparators and repeaters due to broken logic for lever exception.